### PR TITLE
Optimise node label swaps

### DIFF
--- a/bgp_ls_vis/graphing/__init__.py
+++ b/bgp_ls_vis/graphing/__init__.py
@@ -35,6 +35,7 @@ def build_nx_from_lsdb(lsdb: list) -> nx.MultiDiGraph:
                 b_pseudonode = lsa["localNode"]["pseudonode"]
             graph.add_node(lsa["localNode"]["igpRouterId"], pseudonode=b_pseudonode)
 
+    new_name_map = {}
     for lsa in lsdb:
         if lsa["type"] == "Link":
             graph.add_edge(
@@ -43,12 +44,9 @@ def build_nx_from_lsdb(lsdb: list) -> nx.MultiDiGraph:
                 cost=lsa_cost(lsa),
                 pseudonode="pseudonode" in lsa["remoteNode"].keys(),
             )
-
-    # Node type LSAs might have the node's true name (TLV137) under lsattrs
-    # so we prep a rename map (Dict where key: old name, val: new name)
-    # and call nx.relabel_nodes for the current graph, where `copy=false` renames in-place
-    new_name_map = {}
-    for lsa in lsdb:
+        # Node type LSAs might have the node's true name (TLV137) under lsattrs
+        # so we prep a rename map (Dict where key: old name, val: new name)
+        # and call nx.relabel_nodes for the current graph, where `copy=false` renames in-place
         if lsa["type"] == "Node":
             if lsa["lsattribute"]["node"]:
                 if "name" in list(lsa["lsattribute"]["node"].keys()):

--- a/bgp_ls_vis/visualise_web.py
+++ b/bgp_ls_vis/visualise_web.py
@@ -20,20 +20,11 @@ def main():
     nx_graph = graphing.build_nx_from_lsdb(lsdb)
 
     elements = []
-    #pprint(lsdb)
-    for lsa in lsdb:
-        pprint(lsa)
-        print("====================")
-    print(yaml.dump(nx_graph.nodes()))
+
     for node in nx_graph.nodes():
-        node_label = node
-        for lsa in lsdb:
-            if lsa["localNode"]["igpRouterId"] == node and lsa["lsattribute"]["node"]:
-                #print(f"{node}   {lsa['lsattribute']['node']}")
-                node_label = lsa['lsattribute']['node']['name']
         elements.append(
             {
-                "data": {"id": node, "label": node_label},
+                "data": {"id": node, "label": node},
             },
         )
     for source_edge, target_edge in nx_graph.edges():


### PR DESCRIPTION
Since label swap is now part of graphing then remove redundant label swap code from visualiser.

Move node label swap inside existing LSDB for loop to speed up building the graph.